### PR TITLE
Always use the same package ID

### DIFF
--- a/PITCHME.md
+++ b/PITCHME.md
@@ -221,7 +221,7 @@ Test login credentials to make sure you have access.
 @fa[keyboard-o]()&nbsp;Exercise
 <br>
 
-<pre><code class="lang-powershell hljs"><span class="line">choco install putty</span></code></pre>
+<pre><code class="lang-powershell hljs"><span class="line">choco install putty.install</span></code></pre>
 
 @snapend
 


### PR DESCRIPTION
`putty` has a depencency to `putty.portable`, while later `putty.install` is used in examples